### PR TITLE
doc: update readme manual deployment

### DIFF
--- a/node-server/server.js
+++ b/node-server/server.js
@@ -2,7 +2,7 @@ const express = require('express')
 const bcrypt = require('bcrypt')  
 const mongoose = require('mongoose')  
 
-const SERVER_PORT = process.env.SERVER_PORT ? process.env.SERVER_PORT : 5001
+const SERVER_PORT = process.env.SERVER_PORT ? process.env.SERVER_PORT : 5000
 const MONGO_PORT = process.env.MONGO_PORT ? process.env.MONGO_PORT : 27017
 const MONGO_HOST = process.env.MONGO_HOST ? process.env.MONGO_HOST : "localhost"
 

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,19 @@ $ npm install
 $ node server.js
 ```
 
+By default node-server requires mongodb to be run `localhost:27017` and will
+by default expose itself on port `5000`. These can be configured with env
+variables:
+
+```
+$ export SERVER_PORT=<node-server-port> # Default is 5000
+
+$ export MONGO_HOST=<mongo-host> # Default is "localhost"
+$ export MONGO_PORT=<mongo-port> # Default is 27017
+
+$ node server.js
+```
+
 ##### MongoDB server
 
 Make sure you have the mongodb server runnign on port `27017`, if you
@@ -91,6 +104,23 @@ $ python3 -m venv server-env
 $ ./server-env/bin/pip3 install -r server/requirements.txt
 $ ./server-env/bin/python3 server/server.py
 ```
+
+Python server will by default be run on `localhost:3000` and will require
+by default node-server to be run on `localhost:5000`. These can be configured
+with env variables:
+
+```
+$ export NODE_SERVER_HOST=<node-server-host> # Default is "localhost"
+$ export NODE_SERVER_PORT=<node-server-port> # Default is 5000
+
+$ export PYTHON_SERVER_HOST=<python-server-host> # Default is "localhost"
+$ export PYTHON_SERVER_PORT=<python-server-port> # Default is 3000
+
+$ ./server-env/bin/python3 server/server.py
+```
+
+The env variables have different values when deploying with docker compose,
+the values can be found from the `docker-compose.yml` file on repo root.
 
 ## Code Structure
 


### PR DESCRIPTION
* Update manual deployment readme to take into account the newly added environment variables.
* Update node-server default port from 5001 back to 5000. Otherwise the default configurations do not work with each other, since pyserver expects connectivity through port 5000.